### PR TITLE
Fixup settings.yaml and user-management.yaml

### DIFF
--- a/settings.yaml
+++ b/settings.yaml
@@ -520,8 +520,6 @@ paths:
           name: url
           description: The hostname.
           required: true
-      requestBody:
-        content: {}
       tags:
         - DNS
   /api/v1/dns.resolve.srv:
@@ -560,8 +558,6 @@ paths:
           name: url
           description: The hostname.
           required: true
-      requestBody:
-        content: {}
       tags:
         - DNS
   /api/v1/e2e.fetchMyKeys:
@@ -1609,9 +1605,6 @@ paths:
         - $ref: '#/components/parameters/X-Auth-Token'
       tags:
         - Bulk User Import
-      requestBody:
-        content: {}
-        description: ''
   /api/v1/import.status:
     parameters: []
     get:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -4049,8 +4049,6 @@ paths:
         - $ref: '#/components/parameters/UserId'
       tags:
         - Users
-      requestBody:
-        content: {}
   /api/v1/users.2fa.disableEmail:
     parameters: []
     post:
@@ -4104,8 +4102,6 @@ paths:
         - $ref: '#/components/parameters/x-2fa-method'
       tags:
         - Users
-      requestBody:
-        content: {}
   /api/v1/users.2fa.sendEmailCode:
     parameters: []
     post:
@@ -4770,8 +4766,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Auth-Token'
         - $ref: '#/components/parameters/UserId'
-      requestBody:
-        content: {}
   /api/v1/ldap.syncNow:
     post:
       tags:


### PR DESCRIPTION
## Description

Using [openapi-generator-cli](https://openapi-generator.tech/) version `7.20.0`, I get errors validating the specification with

```bash
openapi-generator-cli validate -i settings.yaml
```

and

```bash
openapi-generator-cli validate -i user-management.yaml
```

Output:

```
Validating spec (settings.yaml)
Errors:
	- attribute paths.'/api/v1/dns.resolve.txt'(post).requestBody.content with no media type is
	  unsupported
	- attribute paths.'/api/v1/dns.resolve.srv'(post).requestBody.content with no media type is
	  unsupported
	- attribute paths.'/api/v1/import.run'(post).requestBody.content with no media type is
	  unsupported

[error] Spec has 3 errors.
```

and

```
Validating spec (user-management.yaml)
Errors:
        - attribute paths.'/api/v1/users.2fa.disableEmail'(post).requestBody.content with no media
          type is unsupported
        - attribute paths.'/api/v1/users.2fa.enableEmail'(post).requestBody.content with no media
          type is unsupported
        - attribute paths.'/api/v1/users.logout'(post).requestBody.content with no media type is
          unsupported

[error] Spec has 3 errors.
```

This can be fixed by addressing the error-messages. In this case I checked the endpoints for their request-body and noticed they have none, so I fixed this by removing the `requestBody` annotation from the spec.

List of fixed endpoints:

- https://developer.rocket.chat/apidocs/run-import-operation?highlight=import.run
- https://developer.rocket.chat/apidocs/resolve-dns-text-records
- https://developer.rocket.chat/apidocs/resolve-dns-url-records
- https://developer.rocket.chat/apidocs/logout-user
- https://developer.rocket.chat/apidocs/disable-2fa-email
- https://developer.rocket.chat/apidocs/enable-2fa-with-email

Relates to #107 