### PR TITLE
fix(omnichannel): correct vi to v1 in transcript path

### DIFF
--- a/omnichannel.yaml
+++ b/omnichannel.yaml
@@ -7198,7 +7198,7 @@ paths:
           $ref: '#/components/responses/authorizationError'
         '403':
           $ref: '#/components/responses/permissionError'
-  '/api/vi/omnichannel/{rid}/request-transcript':
+  '/api/v1/omnichannel/{rid}/request-transcript':
     post:
       summary: Request PDF Transcript
       description: |-
@@ -7213,7 +7213,7 @@ paths:
         | Version      | Description |
         | ---------------- | ------------|
         |6.0.0            | Added       |
-      operationId: post-api-vi-omnichannel-rid-request-transcript
+      operationId: post-api-v1-omnichannel-rid-request-transcript
       parameters:
         - name: rid
           in: path


### PR DESCRIPTION
## Summary

Closes #219. `omnichannel.yaml:7201` declared the Request PDF Transcript endpoint at `/api/vi/omnichannel/{rid}/request-transcript` (with `vi` instead of `v1`), and the matching `operationId` at line 7216 carried the same `vi` -> `v1` typo. Because client SDKs and generated bindings consume this spec directly, the entry shipped a path that resolves to a non-existent endpoint at runtime.

## Why this matters

Every other endpoint in `omnichannel.yaml` lives under `/api/v1/omnichannel/...` - the corrected path is the namespace the actual Rocket.Chat backend serves. Without this fix, anyone consuming the OpenAPI spec to drive a generated client gets a 404 on the transcript-request endpoint until they manually patch the path. The `operationId` typo also leaks into generated code (`postApiViOmnichannelRidRequestTranscript`), so the bug is also visible in the names client developers end up working with.

## Changes

- `omnichannel.yaml:7201` - path `vi` -> `v1`.
- `omnichannel.yaml:7216` - operationId `vi` -> `v1`.

No other content in the file touched. The schema below the path (`parameters`, `responses`, request body refs) was already pointed at the correct Rocket.Chat omnichannel components.

## How to test

```
$ grep -n "vi/omnichannel\|vi-omnichannel" omnichannel.yaml
(empty)
$ grep -n "v1/omnichannel/{rid}/request-transcript\|v1-omnichannel-rid-request-transcript" omnichannel.yaml
7201:  '/api/v1/omnichannel/{rid}/request-transcript':
7216:      operationId: post-api-v1-omnichannel-rid-request-transcript
```

Fixes #219

AI-assisted.
