### PR TITLE
API changes 8.6.0-rc.0

### DIFF
--- a/content-management.yaml
+++ b/content-management.yaml
@@ -662,9 +662,7 @@ paths:
         - Custom Sounds
       summary: Delete Custom Sound
       description: |-
-        Delete a custom sound from the workspace by its `_id`. This also removes the associated audio file from storage.
-
-        This endpoint replaces the deprecated DDP method `deleteCustomSound`, which now logs a deprecation warning and is scheduled for removal in `9.0.0`.
+        Delete a custom sound from the workspace by its `_id`. This also removes the associated audio file from storage. This endpoint replaces the deprecated DDP method `deleteCustomSound`, which now logs a deprecation warning and is scheduled for removal in `9.0.0`.
 
         Permission required: `manage-sounds`
 
@@ -739,23 +737,6 @@ paths:
                     success: false
                     error: 'User does not have the permissions required for this action [error-unauthorized]'
                     errorType: error-unauthorized
-        # <!-- TODO: Verify the exact status code returned when `_id` does not match an existing sound. The endpoint's response validators declare both 404 (validateNotFoundErrorResponse) and 500 (validateInternalErrorResponse), but the handler in apps/meteor/app/api/server/v1/custom-sounds.ts maps the `Custom_Sound_Error_Invalid_Sound` error to API.v1.failure (400) and falls back to API.v1.internalError (500) for other errors. Confirm whether a 404 is ever returned in practice before documenting it. -->
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                  error:
-                    type: string
-              examples:
-                Internal Error:
-                  value:
-                    success: false
-                    error: Internal server error
   /api/v1/custom-user-status.list:
     get:
       tags:

--- a/content-management.yaml
+++ b/content-management.yaml
@@ -656,6 +656,106 @@ paths:
                     success: false
                     error: 'User does not have the permissions required for this action [error-unauthorized]'
                     errorType: error-unauthorized
+  /api/v1/custom-sounds.delete:
+    post:
+      tags:
+        - Custom Sounds
+      summary: Delete Custom Sound
+      description: |-
+        Delete a custom sound from the workspace by its `_id`. This also removes the associated audio file from storage.
+
+        This endpoint replaces the deprecated DDP method `deleteCustomSound`, which now logs a deprecation warning and is scheduled for removal in `9.0.0`.
+
+        Permission required: `manage-sounds`
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.6.0   | Added       |
+      operationId: post-api-v1-custom-sounds.delete
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _id:
+                  type: string
+                  description: The ID of the custom sound to delete. Must be at least one character long.
+                  example: 65462caea2f73c7460e18f83
+              required:
+                - _id
+            examples:
+              Example:
+                value:
+                  _id: 65462caea2f73c7460e18f83
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid sound:
+                  value:
+                    success: false
+                    error: Custom_Sound_Error_Invalid_Sound
+                Missing required field:
+                  value:
+                    success: false
+                    error: 'must have required property ''_id'' [invalid-params]'
+                    errorType: invalid-params
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Permission Error:
+                  value:
+                    success: false
+                    error: 'User does not have the permissions required for this action [error-unauthorized]'
+                    errorType: error-unauthorized
+        # <!-- TODO: Verify the exact status code returned when `_id` does not match an existing sound. The endpoint's response validators declare both 404 (validateNotFoundErrorResponse) and 500 (validateInternalErrorResponse), but the handler in apps/meteor/app/api/server/v1/custom-sounds.ts maps the `Custom_Sound_Error_Invalid_Sound` error to API.v1.failure (400) and falls back to API.v1.internalError (500) for other errors. Confirm whether a 404 is ever returned in practice before documenting it. -->
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+              examples:
+                Internal Error:
+                  value:
+                    success: false
+                    error: Internal server error
   /api/v1/custom-user-status.list:
     get:
       tags:

--- a/messaging.yaml
+++ b/messaging.yaml
@@ -21,9 +21,12 @@ paths:
           * The `delete-own-message` permission is required to delete users' own messages.
           * The `delete-message` permission is required for users to delete messages from other users.
 
+        You can delete a message by its `roomId` and `msgId`, or delete a message by its `fileId` to remove the message that holds an uploaded file.
+
         ### Changelog
-        | Version      | Description | 
+        | Version      | Description |
         | ---------------- | ------------|
+        | 8.6.0            | Added `fileId` to delete a message by the file it contains. |
         | 0.48.0           | Added       |
       operationId: post-api-v1-chat.delete
       parameters:
@@ -35,25 +38,30 @@ paths:
           application/json:
             schema:
               type: object
+              description: |-
+                Provide either `roomId` and `msgId` together, or `fileId` on its own.
               properties:
                 roomId:
                   type: string
-                  description: The room ID
+                  description: The room ID. Required when deleting by `msgId`.
                 msgId:
                   type: string
-                  description: The ID of the message to delete.
+                  description: The ID of the message to delete. Required together with `roomId`.
+                fileId:
+                  type: string
+                  description: The ID of the uploaded file whose message you want to delete. Use this instead of `roomId` and `msgId` to delete the message that contains the file.
                 asUser:
                   type: boolean
                   description: Should the message be deleted as the user who sent it? It is `false` by default.
-              required:
-                - roomId
-                - msgId
             examples:
-              Example:
+              Delete by message:
                 value:
                   roomId: ByehQjC44FwMeiLbX
                   msgId: 7aDSXtjMA3KPLxLjt
                   asUser: false
+              Delete by file:
+                value:
+                  fileId: 9aFcj4XmgQ7eYpLbT
       responses:
         '200':
           description: OK
@@ -3705,6 +3713,72 @@ paths:
           name: url
           description: Enter the URL that you want to preview.
           required: true
+  /api/v1/im.blockUser:
+    post:
+      tags:
+        - DM
+      summary: Block User in DM
+      description: |-
+        Blocks or unblocks the other user in a direct message room. Set `block` to `true` to block the user, or `false` to unblock them. The endpoint blocks or unblocks the room member who is not the authenticated user.
+
+        This endpoint replaces the deprecated `blockUser` and `unblockUser` DDP methods. The DDP methods log a deprecation warning and remain available until 9.0.0.
+
+        ### Changelog
+        | Version      | Description |
+        | ------------ | ------------|
+        | 8.6.0        | Added       |
+      operationId: post-api-v1-im.blockUser
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                roomId:
+                  type: string
+                  description: The direct message room ID.
+                block:
+                  type: boolean
+                  description: Set to `true` to block the other user, or `false` to unblock them.
+              required:
+                - roomId
+                - block
+            examples:
+              Block:
+                value:
+                  roomId: ByehQjC44FwMeiLbX
+                  block: true
+              Unblock:
+                value:
+                  roomId: ByehQjC44FwMeiLbX
+                  block: false
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid room:
+                  value:
+                    success: false
+                    error: 'Invalid room [error-invalid-room]'
+                    errorType: error-invalid-room
+        '401':
+          $ref: '#/components/responses/authorizationError'
   /api/v1/dm.close:
     post:
       tags:

--- a/miscellaneous.yaml
+++ b/miscellaneous.yaml
@@ -693,12 +693,15 @@ paths:
   /api/v1/spotlight:
     get:
       summary: Spotlight
-      description: |- 
+      description: |-
         Searches for users or rooms that are visible to the user. It will only return rooms that user didn't join yet.
-        
+
+        If the `Accounts_AllowAnonymousRead` setting is enabled, anonymous callers can use this endpoint to resolve public channels through the navbar search.
+
         ### Changelog
         | Version      | Description |
         | ---------------- | ------------|
+        | 8.6.0       | Added `usernames`, `type`, and `rid` query parameters, and allowed anonymous read when `Accounts_AllowAnonymousRead` is enabled. |
         |0.64.0       | Added support to '#' and '@' searches, for channels and users respectively.       |
         |0.61.0      | Added       |
       operationId: get-api-v1-spotlight
@@ -712,6 +715,27 @@ paths:
           schema:
             type: string
           example: john
+        - name: usernames
+          in: query
+          description: Comma-separated list of usernames to exclude from the user results.
+          required: false
+          schema:
+            type: string
+          example: 'rocket.cat,john.doe'
+        - name: type
+          in: query
+          description: Restricts the search to a single result type. Accepts `users` or `rooms`.
+          required: false
+          schema:
+            type: string
+          example: users
+        - name: rid
+          in: query
+          description: The room ID to scope the user search to a specific room.
+          required: false
+          schema:
+            type: string
+          example: GENERAL
       responses:
         '200':
           description: OK
@@ -781,6 +805,81 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Auth-Token'
         - $ref: '#/components/parameters/UserId'
+  /api/v1/fingerprint:
+    post:
+      summary: Update Fingerprint
+      description: |-
+        Confirms how the workspace deployment fingerprint should be interpreted after a change to its configuration. Use `new-workspace` to register the deployment as a new workspace and clear the existing <a href='https://docs.rocket.chat/docs/cloud-services' target='_blank'>Rocket.Chat Cloud</a> credentials, or `updated-configuration` to keep the current registration.
+
+        Permission required: `manage-cloud`
+
+        ### Changelog
+        | Version     | Description |
+        | ----------- | ----------- |
+        | 8.6.0       | Added an authorization check. Callers without the `manage-cloud` permission now receive a `403` error instead of a successful response. |
+      operationId: post-api-v1-fingerprint
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                setDeploymentAs:
+                  type: string
+                  description: How to interpret the deployment after the configuration change. Either `new-workspace` or `updated-configuration`.
+                  example: new-workspace
+              required:
+                - setDeploymentAs
+            examples:
+              Example 1:
+                value:
+                  setDeploymentAs: new-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Example 1:
+                  value:
+                    success: false
+                    error: 'Invalid body params'
+                    errorType: error-invalid-body-params
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Permission Error:
+                  value:
+                    success: false
+                    error: 'User does not have the permissions required for this action [error-unauthorized]'
+                    errorType: error-unauthorized
   /api/v1/licenses.info:
     get:
       tags:

--- a/rooms.yaml
+++ b/rooms.yaml
@@ -5567,6 +5567,154 @@ paths:
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
+  /api/v1/rooms.join:
+    post:
+      tags:
+        - Rooms
+      summary: Join a Room
+      description: |-
+        Join a room of any type, including public channels, private groups, and discussions.
+
+        Unlike the <a href='https://developer.rocket.chat/apidocs/join-a-channel' target='_blank'>channels.join</a> endpoint, which only joins public channels, this endpoint resolves all room types and applies the room's access checks, join code requirements, federation rules, and Omnichannel rules.
+
+        Provide either `roomId` or `roomName` to identify the room. If the room is password-protected, also provide `joinCode`. The join code isn't needed if the user has the `join-without-join-code` permission.
+
+        ### Changelog
+        | Version      | Description |
+        | ------------ | ----------- |
+        | 8.6.0-rc.0   | Added       |
+      operationId: post-api-v1-rooms.join
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  properties:
+                    roomId:
+                      type: string
+                      description: The ID of the room to join. Provide either `roomId` or `roomName`.
+                      example: ByehQjC44FwMeiLbX
+                    joinCode:
+                      type: string
+                      description: |-
+                        The join code of the room. Rooms can be password-protected. In that case, users must enter the password for access. The join code isn't needed if the user has the `join-without-join-code` permission.
+                      example: '1234'
+                  required:
+                    - roomId
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    roomName:
+                      type: string
+                      description: The name of the room to join. Provide either `roomId` or `roomName`.
+                      example: general
+                    joinCode:
+                      type: string
+                      description: |-
+                        The join code of the room. Rooms can be password-protected. In that case, users must enter the password for access. The join code isn't needed if the user has the `join-without-join-code` permission.
+                      example: '1234'
+                  required:
+                    - roomName
+                  additionalProperties: false
+            examples:
+              Join by room ID:
+                value:
+                  roomId: ByehQjC44FwMeiLbX
+                  joinCode: '1234'
+              Join by room name:
+                value:
+                  roomName: general
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  room:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                      name:
+                        type: string
+                      fname:
+                        type: string
+                      t:
+                        type: string
+                      msgs:
+                        type: integer
+                      usersCount:
+                        type: integer
+                      u:
+                        type: object
+                        properties:
+                          _id:
+                            type: string
+                          username:
+                            type: string
+                      ts:
+                        type: string
+                      ro:
+                        type: boolean
+                      default:
+                        type: boolean
+                      sysMes:
+                        type: boolean
+                      _updatedAt:
+                        type: string
+                  success:
+                    type: boolean
+              examples:
+                Example:
+                  value:
+                    room:
+                      _id: ByehQjC44FwMeiLbX
+                      name: general
+                      fname: general
+                      t: c
+                      msgs: 8
+                      usersCount: 2
+                      u:
+                        _id: rocketchat.internal.admin.test
+                        username: rocketchat.internal.admin.test
+                      ts: '2026-01-16T12:00:04.783Z'
+                      ro: false
+                      sysMes: true
+                      default: true
+                      _updatedAt: '2026-01-16T12:06:30.426Z'
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid params:
+                  value:
+                    success: false
+                    error: 'Match error: Missing key ''roomId'''
+                    errorType: error-invalid-params
+                Room not found:
+                  value:
+                    success: false
+                    error: 'The required "roomId" or "roomName" param provided does not match any channel [error-room-not-found]'
+                    errorType: error-room-not-found
+        '401':
+          $ref: '#/components/responses/authorizationError'
   /api/v1/rooms.leave:
     post:
       tags:

--- a/settings.yaml
+++ b/settings.yaml
@@ -266,6 +266,103 @@ paths:
           description: 'When set to true, it fetches both the current value and the default value (packageValue) of the settings'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/count'
+    post:
+      summary: Update Settings in Bulk
+      operationId: post-api-v1-settings
+      description: |-
+        Updates multiple private settings in a single request. Provide an array of settings, each with its `_id` and the `value` to set.
+
+        Permission required: `edit-privileged-setting`
+
+        This endpoint requires two-factor authentication.
+
+        This endpoint replaces the deprecated `saveSettings` DDP method. The DDP method logs a deprecation warning and remains available until 9.0.0.
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.6.0            | Added       |
+      tags:
+        - Settings
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+        - $ref: '#/components/parameters/x-2fa-code'
+        - $ref: '#/components/parameters/X-2fa-method'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                settings:
+                  type: array
+                  description: The list of settings to update.
+                  minItems: 1
+                  items:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                        description: The unique ID of the setting.
+                      value:
+                        description: The value to set for the setting. The accepted type depends on the setting.
+                    required:
+                      - _id
+                      - value
+              required:
+                - settings
+            examples:
+              Example:
+                value:
+                  settings:
+                    - _id: API_Allow_Infinite_Count
+                      value: false
+                    - _id: API_CORS_Origin
+                      value: 'https://example.com'
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid Params:
+                  value:
+                    success: false
+                    error: 'must have required property ''settings'' [invalid-params]'
+                    errorType: invalid-params
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Permission Error:
+                  value:
+                    success: false
+                    error: 'User does not have the permissions required for this action [error-unauthorized]'
+                    errorType: error-unauthorized
   /api/v1/settings.addCustomOAuth:
     parameters: []
     post:
@@ -872,6 +969,29 @@ paths:
                   uid: d26x6zSkaPSe5gCyy
                   rid: 9R1V4t3_k3Y
                   key: M4-Ubd4T3d-k39
+  /api/v1/e2e.requestSubscriptionKeys:
+    post:
+      summary: Request Subscription Keys
+      operationId: post-api-v1-e2e.requestSubscriptionKeys
+      description: |-
+        Requests the E2E encryption keys for the rooms the authenticated user is subscribed to. Other room members are notified to share their keys with the requesting user.
+
+        This endpoint replaces the deprecated `e2e.requestSubscriptionKeys` DDP method. The DDP method logs a deprecation warning and remains available until 9.0.0.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ------------|
+        | 8.6.0   | Added       |
+      tags:
+        - E2E
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '401':
+          $ref: '#/components/responses/authorizationError'
   /api/v1/uploadImportFile:
     parameters: []
     post:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -2579,10 +2579,11 @@ paths:
         * You can set the status for yourself or another user. The `AllowUserStatusMessageChange` setting must be enabled in the `Accounts` workspace settings.
         * To change another user's status, you must have the `edit-other-user-info` permission.
         * According to your workspace settings (under **Accounts**), you will only be able to set the invisible or `offline` status if the `Allow Invisible status option` setting is enabled.
-          
+
           ### Changelog
           | Version      | Description |
           | ---------------- | ------------|
+          |8.6.0            | Added the `expiresAt` parameter to set an expiration time for the status, after which the presence engine restores the previous status. |
           |1.2.0            | Added       |
       parameters:
         - $ref: '#/components/parameters/UserId'
@@ -2603,6 +2604,10 @@ paths:
                     The user's status like `online`, `away`, `busy`, or
                     `offline`. At least one of the `message` or `status` parameters is required.
                   example: online
+                expiresAt:
+                  type: string
+                  description: Date as an ISO 8601 string. Sets an expiration time for the status. When this time passes, the presence engine restores the user's previous status. Omit this parameter to keep the status until it is changed again.
+                  example: '2026-06-22T18:00:00.000Z'
                 userId:
                   type: string
                   example: zXuq7SvPKYbzYmfpo
@@ -2615,6 +2620,7 @@ paths:
                 value:
                   message: My status update
                   status: online
+                  expiresAt: '2026-06-22T18:00:00.000Z'
                   userId: zXuq7SvPKYbzYmfpo
                   username: bob
       tags:
@@ -2626,10 +2632,11 @@ paths:
       summary: Get Status
       description: |-
         Gets a user's status in your workspace.
-        
+
         ### Changelog
         | Version      | Description |
         | ---------------- | ------------|
+        |8.6.0            | Added `statusSource` and `statusExpiresAt` to the response. `statusSource` reports which claim set the current status: `internal`, `manual`, or `external`. |
         |1.2.0            | Added       |
       operationId: get-api-v1-users.getStatus
       parameters:
@@ -2650,20 +2657,31 @@ paths:
               schema:
                 type: object
                 properties:
+                  _id:
+                    type: string
                   message:
                     type: string
                   connectionStatus:
                     type: string
                   status:
                     type: string
+                  statusSource:
+                    type: string
+                    description: The claim that set the current status. One of `internal`, `manual`, or `external`. Omitted when the user has no recorded status source.
+                  statusExpiresAt:
+                    type: string
+                    description: Date as an ISO 8601 string indicating when the current status expires. Omitted when the status has no expiration.
                   success:
                     type: boolean
               examples:
                 Success Example:
                   value:
+                    _id: W7NHuX5ri2e3mu2Fc
                     message: Latest status
                     connectionStatus: online
                     status: online
+                    statusSource: manual
+                    statusExpiresAt: '2026-06-22T18:00:00.000Z'
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
@@ -2940,6 +2958,12 @@ paths:
                           type: string
                         utcOffset:
                           type: integer
+                        statusSource:
+                          type: string
+                          description: The claim that set the user's current status. One of `internal`, `manual`, or `external`. Omitted when the user has no recorded status source.
+                        statusExpiresAt:
+                          type: string
+                          description: Date as an ISO 8601 string indicating when the user's current status expires. Omitted when the status has no expiration.
                         avatarETag:
                           type: string
                   full:
@@ -2955,12 +2979,15 @@ paths:
                         username: rocket.cat
                         status: online
                         utcOffset: 0
+                        statusSource: internal
                         avatarETag: 5BB9B5ny5DkKdrwkq
                       - _id: rocketchat.internal.admin.test
                         name: RocketChat Internal Admin Test
                         username: rocketchat.internal.admin.test
                         status: online
                         utcOffset: -2
+                        statusSource: manual
+                        statusExpiresAt: '2026-06-22T18:00:00.000Z'
                         avatarETag: iEbEm4bTT327NJjXt
                     full: true
                     success: true
@@ -2992,6 +3019,7 @@ paths:
         ### Changelog
         | Version      | Description |
         | ---------------- | ------------|
+        |8.6.0            | Added `statusSource` and `statusExpiresAt` to each returned user. `statusSource` reports which claim set the status: `internal`, `manual`, or `external`. |
         |8.5.0            | Restored support for comma-separated values in `ids`.       |
         |1.1.0            | Added       |
       tags:
@@ -3523,6 +3551,7 @@ paths:
         ### Changelog
         | Version      | Description |
         | ---------------- | ------------|
+        |8.6.0            | Added `utcOffset` property.       |
         |2.3.0            | Added `desktopNotificationRequireInteraction` property.       |
       parameters:
         - $ref: '#/components/parameters/UserId'
@@ -3727,6 +3756,10 @@ paths:
                     enableMobileRinging:
                       type: boolean
                       description: 'If you are using the Rocket.Chat Voice feature, you can set this parameter to true for mobile call notifications.'
+                    utcOffset:
+                      type: number
+                      description: The user's UTC offset in hours. Used to localize times such as notification schedules.
+                      example: -3
             examples:
               Example 1:
                 value:
@@ -5362,14 +5395,17 @@ paths:
                     success: false
                     error: 'must have required property ''email'' [invalid-params]'
                     errorType: invalid-params
-        '401':
-          $ref: '#/components/responses/authorizationError'
       operationId: post-api-v1-users.sendConfirmationEmail
       description: |-
-       Send an email to verify a user's email address. The user receives the email and they must click the confirmation button to confirm their email address. Rate limit applies: One request can be sent every 60000ms.
-      parameters:
-        - $ref: '#/components/parameters/Auth-Token'
-        - $ref: '#/components/parameters/UserId'
+        Send an email to verify a user's email address. The user receives the email and they must click the confirmation button to confirm their email address. Rate limit applies: One request can be sent every 60000ms.
+
+        This endpoint does not require authentication. An unverified user can call it from the login screen to resend their own verification email.
+
+        ### Changelog
+        | Version    | Description                            |
+        | ---------- | -------------------------------------- |
+        | 8.6.0-rc.0 | Authentication is no longer required.  |
+      parameters: []
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Document REST API changes for the 8.6.0-rc.0 release.

New endpoints:
- POST /api/v1/custom-sounds.delete (content-management.yaml)
- POST /api/v1/fingerprint — now documents the manage-cloud authorization requirement (miscellaneous.yaml)
- POST /api/v1/rooms.join (rooms.yaml)
- POST /api/v1/im.blockUser (messaging.yaml)
- POST /api/v1/e2e.requestSubscriptionKeys, POST /api/v1/settings (settings.yaml)

Updated endpoints:
- POST /api/v1/chat.delete — add fileId (messaging.yaml)
- GET /api/v1/spotlight — add usernames/type/rid + anonymous read (miscellaneous.yaml)
- POST /api/v1/users.setPreferences — add utcOffset (user-management.yaml)
- GET /api/v1/users.getStatus, GET /api/v1/users.presence, POST /api/v1/users.setStatus — presence engine fields statusSource/statusExpiresAt/expiresAt (user-management.yaml)
- POST /api/v1/users.sendConfirmationEmail — authentication no longer required (user-management.yaml)

Each endpoint has an appended 8.6.0 changelog row. See api-changes-summary-8.6.0-rc.0.md for full detail.