### PR TITLE
8.6.0 changes

### DIFF
--- a/content-management.yaml
+++ b/content-management.yaml
@@ -1172,6 +1172,87 @@ paths:
                     errorType: invalid-params
         '401':
           $ref: '#/components/responses/authorizationError'
+  /api/v1/custom-sounds.delete:
+    post:
+      tags:
+        - Custom Sounds
+      summary: Delete Custom Sound
+      description: |-
+        Delete a custom sound from the workspace by its `_id`. This also removes the associated audio file from storage. This endpoint replaces the deprecated DDP method `deleteCustomSound`, which now logs a deprecation warning and is scheduled for removal in `9.0.0`.
+
+        Permission required: `manage-sounds`
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.6.0   | Added       |
+      operationId: post-api-v1-custom-sounds.delete
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                _id:
+                  type: string
+                  description: The ID of the custom sound to delete. Must be at least one character long.
+                  example: 65462caea2f73c7460e18f83
+              required:
+                - _id
+            examples:
+              Example:
+                value:
+                  _id: 65462caea2f73c7460e18f83
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid sound:
+                  value:
+                    success: false
+                    error: Custom_Sound_Error_Invalid_Sound
+                Missing required field:
+                  value:
+                    success: false
+                    error: 'must have required property ''_id'' [invalid-params]'
+                    errorType: invalid-params
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Permission Error:
+                  value:
+                    success: false
+                    error: 'User does not have the permissions required for this action [error-unauthorized]'
+                    errorType: error-unauthorized 
   /api/v1/custom-sounds.getOne:
     get:
       summary: Get Custom Sound

--- a/messaging.yaml
+++ b/messaging.yaml
@@ -21,9 +21,12 @@ paths:
           * The `delete-own-message` permission is required to delete users' own messages.
           * The `delete-message` permission is required for users to delete messages from other users.
 
+        You can delete a message by its `roomId` and `msgId`, or delete a message by its `fileId` to remove the message that holds an uploaded file.
+
         ### Changelog
-        | Version      | Description | 
+        | Version      | Description |
         | ---------------- | ------------|
+        | 8.6.0            | Added `fileId` to delete a message by the file it contains. |
         | 0.48.0           | Added       |
       operationId: post-api-v1-chat.delete
       parameters:
@@ -35,25 +38,30 @@ paths:
           application/json:
             schema:
               type: object
+              description: |-
+                Provide either `roomId` and `msgId` together, or `fileId` on its own.
               properties:
                 roomId:
                   type: string
-                  description: The room ID
+                  description: The room ID. Required when deleting by `msgId`.
                 msgId:
                   type: string
-                  description: The ID of the message to delete.
+                  description: The ID of the message to delete. Required together with `roomId`.
+                fileId:
+                  type: string
+                  description: The ID of the uploaded file whose message you want to delete. Use this instead of `roomId` and `msgId` to delete the message that contains the file.
                 asUser:
                   type: boolean
                   description: Should the message be deleted as the user who sent it? It is `false` by default.
-              required:
-                - roomId
-                - msgId
             examples:
-              Example:
+              Delete by message:
                 value:
                   roomId: ByehQjC44FwMeiLbX
                   msgId: 7aDSXtjMA3KPLxLjt
                   asUser: false
+              Delete by file:
+                value:
+                  fileId: 9aFcj4XmgQ7eYpLbT
       responses:
         '200':
           description: OK
@@ -85,7 +93,7 @@ paths:
                   success:
                     type: boolean
               examples:
-                Example 1:
+                Example:
                   value:
                     _id: jEnjsxuoDJamGjbH2
                     ts: '1696533809813'
@@ -109,10 +117,10 @@ paths:
                   error:
                     type: string
               examples:
-                Example 1:
+                Invalid Message ID:
                   value:
                     success: false
-                    error: The room id provided does not match where the message is from.
+                    error: No message found with the id of \"MvHcX2WKSrmdArmktz\".
         '401':
           $ref: '#/components/responses/authorizationError'
   /api/v1/chat.react:

--- a/messaging.yaml
+++ b/messaging.yaml
@@ -3713,6 +3713,70 @@ paths:
           name: url
           description: Enter the URL that you want to preview.
           required: true
+  /api/v1/im.blockUser:
+    post:
+      tags:
+        - DM
+      summary: Block User in DM
+      description: |-
+        Blocks or unblocks the other user in a direct message room. This endpoint replaces the deprecated `blockUser` and `unblockUser` DDP methods.
+
+        ### Changelog
+        | Version      | Description |
+        | ------------ | ------------|
+        | 8.6.0        | Added       |
+      operationId: post-api-v1-im.blockUser
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                roomId:
+                  type: string
+                  description: The direct message room ID.
+                block:
+                  type: boolean
+                  description: Set to `true` to block the other user, or `false` to unblock them.
+              required:
+                - roomId
+                - block
+            examples:
+              Block User:
+                value:
+                  roomId: ByehQjC44FwMeiLbX
+                  block: true
+              Unblock User:
+                value:
+                  roomId: ByehQjC44FwMeiLbX
+                  block: false
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid room:
+                  value:
+                    success: false
+                    error: '[invalid-channel]'
+                    errorType: invalid-channel
+        '401':
+          $ref: '#/components/responses/authorizationError'        
   /api/v1/dm.close:
     post:
       tags:

--- a/miscellaneous.yaml
+++ b/miscellaneous.yaml
@@ -805,6 +805,92 @@ paths:
       parameters:
         - $ref: '#/components/parameters/Auth-Token'
         - $ref: '#/components/parameters/UserId'
+  /api/v1/fingerprint:
+    post:
+      summary: Update Fingerprint
+      description: |-
+        Confirms how the workspace deployment should be handled after Rocket.Chat detects a change to its deployment fingerprint.
+
+        On startup, Rocket.Chat generates a deployment fingerprint based on the configured Site_Url and MongoDB connection string. If the generated fingerprint differs from the stored value, Rocket.Chat assumes the workspace may have been duplicated, migrated, or reconfigured.
+
+        Use this endpoint to confirm how the deployment should be treated:
+
+        - `new-workspace`: Treats the deployment as a new workspace. This clears the existing Rocket.Chat Cloud registration data and related credentials so the workspace can register again as a new instance. Use this option for cloned environments, staging instances created from production backups, or other duplicated deployments.
+
+        - `updated-configuration`: Confirms that the deployment is the same workspace and that only its configuration has changed. This preserves the existing Rocket.Chat Cloud registration and is intended for legitimate migrations, infrastructure changes, or Site_Url updates.
+
+        After processing either option, Rocket.Chat marks the deployment fingerprint as verified and dismisses the fingerprint verification prompt.
+
+        Permission required: `manage-cloud`
+          
+        ### Changelog
+        | Version | Description | 
+        | ------- | ----------- | 
+        | 8.6.0 | Added an authorization check. Callers without the `manage-cloud` permission now receive a `403` error instead of a successful response. |
+      operationId: post-api-v1-fingerprint
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                setDeploymentAs:
+                  type: string
+                  description: |-
+                    Specifies how Rocket.Chat should handle a detected deployment fingerprint change. Use `new-workspace` to reset the current workspace registration and register the deployment as a new workspace, or `updated-configuration` to preserve the existing workspace registration and confirm that only the deployment configuration has changed. Either `new-workspace` or `updated-configuration`.
+                  example: new-workspace
+              required:
+                - setDeploymentAs
+            examples:
+              Example:
+                value:
+                  setDeploymentAs: new-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid Parameter:
+                  value:
+                    success: false
+                    error: 'Invalid body params'
+                    errorType: error-invalid-body-params
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Permission Error:
+                  value:
+                    success: false
+                    error: 'User does not have the permissions required for this action [error-unauthorized]'
+                    errorType: error-unauthorized
   /api/v1/licenses.info:
     get:
       tags:

--- a/miscellaneous.yaml
+++ b/miscellaneous.yaml
@@ -693,12 +693,15 @@ paths:
   /api/v1/spotlight:
     get:
       summary: Spotlight
-      description: |- 
+      description: |-
         Searches for users or rooms that are visible to the user. It will only return rooms that user didn't join yet.
-        
+
+        If the  <a href="https://docs.rocket.chat/docs/accounts" target="_blank">`Allow Anonymous Read` setting</a> is enabled, anonymous callers can use this endpoint to resolve public channels through the navbar search.
+
         ### Changelog
         | Version      | Description |
         | ---------------- | ------------|
+        | 8.6.0       | Added `usernames`, `type`, and `rid` query parameters, and allowed anonymous read when `Allow Anonymous Read` is enabled. |
         |0.64.0       | Added support to '#' and '@' searches, for channels and users respectively.       |
         |0.61.0      | Added       |
       operationId: get-api-v1-spotlight
@@ -712,6 +715,27 @@ paths:
           schema:
             type: string
           example: john
+        - name: usernames
+          in: query
+          description: Comma-separated list of usernames to exclude from the user results.
+          required: false
+          schema:
+            type: string
+          example: 'rocket.cat,john.doe'
+        - name: type
+          in: query
+          description: Restricts the search to a single result type. Accepts `users` or `rooms`.
+          required: false
+          schema:
+            type: string
+          example: users
+        - name: rid
+          in: query
+          description: The room ID to scope the user search to a specific room.
+          required: false
+          schema:
+            type: string
+          example: GENERAL
       responses:
         '200':
           description: OK

--- a/rooms.yaml
+++ b/rooms.yaml
@@ -5597,6 +5597,150 @@ paths:
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
+  /api/v1/rooms.join:
+    post:
+      tags:
+        - Rooms
+      summary: Join a Room
+      description: |-
+        Join a room of any type, including public channels, private groups, and discussions. Unlike the <a href='https://developer.rocket.chat/apidocs/join-a-channel' target='_blank'>channels.join</a> endpoint, which only joins public channels, this endpoint applies to all kinds of rooms. 
+
+        ### Changelog
+        | Version      | Description |
+        | ------------ | ----------- |
+        | 8.6.0   | Added       |
+      operationId: post-api-v1-rooms.join
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - type: object
+                  properties:
+                    roomId:
+                      type: string
+                      description: The ID of the room to join. Provide either `roomId` or `roomName`.
+                      example: ByehQjC44FwMeiLbX
+                    joinCode:
+                      type: string
+                      description: |-
+                        The join code of the room. Rooms can be password-protected. In that case, users must enter the password for access. The join code isn't needed if the user has the `join-without-join-code` permission.
+                      example: '1234'
+                  required:
+                    - roomId
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    roomName:
+                      type: string
+                      description: The name of the room to join. Provide either `roomId` or `roomName`.
+                      example: general
+                    joinCode:
+                      type: string
+                      description: |-
+                        The join code of the room. Rooms can be password-protected. In that case, users must enter the password for access. The join code isn't needed if the user has the `join-without-join-code` permission.
+                      example: '1234'
+                  required:
+                    - roomName
+                  additionalProperties: false
+            examples:
+              Join by room ID:
+                value:
+                  roomId: ByehQjC44FwMeiLbX
+                  joinCode: '1234'
+              Join by room name:
+                value:
+                  roomName: general
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  room:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                      name:
+                        type: string
+                      fname:
+                        type: string
+                      t:
+                        type: string
+                      msgs:
+                        type: integer
+                      usersCount:
+                        type: integer
+                      u:
+                        type: object
+                        properties:
+                          _id:
+                            type: string
+                          username:
+                            type: string
+                      ts:
+                        type: string
+                      ro:
+                        type: boolean
+                      default:
+                        type: boolean
+                      sysMes:
+                        type: boolean
+                      _updatedAt:
+                        type: string
+                  success:
+                    type: boolean
+              examples:
+                Example:
+                  value:
+                    room:
+                      _id: ByehQjC44FwMeiLbX
+                      name: general
+                      fname: general
+                      t: c
+                      msgs: 8
+                      usersCount: 2
+                      u:
+                        _id: rocketchat.internal.admin.test
+                        username: rocketchat.internal.admin.test
+                      ts: '2026-01-16T12:00:04.783Z'
+                      ro: false
+                      sysMes: true
+                      default: true
+                      _updatedAt: '2026-01-16T12:06:30.426Z'
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid params:
+                  value:
+                    success: false
+                    error: 'Match error: Missing key ''roomId'''
+                    errorType: error-invalid-params
+                Room not found:
+                  value:
+                    success: false
+                    error: 'The required "roomId" or "roomName" param provided does not match any channel [error-room-not-found]'
+                    errorType: error-room-not-found
+        '401':
+          $ref: '#/components/responses/authorizationError'       
   /api/v1/rooms.leave:
     post:
       tags:

--- a/settings.yaml
+++ b/settings.yaml
@@ -266,104 +266,6 @@ paths:
           description: 'When set to true, it fetches both the current value and the default value (packageValue) of the settings'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/count'
-    post:
-      summary: Update Settings in Bulk
-      operationId: post-api-v1-settings
-      description: |-
-        Update multiple private settings in a single request.This endpoint replaces the deprecated `saveSettings` DDP method.
-
-        Permission required: `Edit Privileged Setting` 
-
-        ### Changelog
-        | Version      | Description |
-        | ---------------- | ------------|
-        |8.6.0            | Added       |
-      tags:
-        - Settings
-      parameters:
-        - $ref: '#/components/parameters/X-User-Id'
-        - $ref: '#/components/parameters/X-Auth-Token'
-        - $ref: '#/components/parameters/x-2fa-code'
-        - $ref: '#/components/parameters/X-2fa-method'
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                settings:
-                  type: array
-                  description: The list of settings to update.
-                  minItems: 1
-                  items:
-                    type: object
-                    properties:
-                      _id:
-                        type: string
-                        description: The unique ID of the setting.
-                      value:
-                        description: The value to set for the setting. The accepted type depends on the setting.
-                    required:
-                      - _id
-                      - value
-              required:
-                - settings
-            examples:
-              Example:
-                value:
-                  settings:
-                    - _id: API_Allow_Infinite_Count
-                      value: false
-                    - _id: API_CORS_Origin
-                      value: 'https://example.com'
-      responses:
-        '200':
-          $ref: '#/components/responses/trueSuccess'
-        '400':
-          description: Bad Request
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                  error:
-                    type: string
-                  errorType:
-                    type: string
-              examples:
-                Invalid Params:
-                  value:
-                    success: false
-                    error: 'must have required property ''settings'' [invalid-params]'
-                    errorType: invalid-params
-        '401':
-          $ref: '#/components/responses/authorizationError'
-        '403':
-          description: Forbidden
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  success:
-                    type: boolean
-                  error:
-                    type: string
-                  errorType:
-                    type: string
-              examples:
-                Permission Error:
-                  value:
-                    success: false
-                    error: 'Editing settings is not allowed [error-action-not-allowed]'
-                    errorType: error-action-not-allowed
-                    details:
-                      method: saveSettings
-                      settingIds:
-                        - API_Allow_Infinite_Count
-                        - API_CORS_Origin
   /api/v1/settings.addCustomOAuth:
     parameters: []
     post:
@@ -970,6 +872,27 @@ paths:
                   uid: d26x6zSkaPSe5gCyy
                   rid: 9R1V4t3_k3Y
                   key: M4-Ubd4T3d-k39
+  /api/v1/e2e.requestSubscriptionKeys:
+    post:
+      summary: Request Subscription Keys
+      operationId: post-api-v1-e2e.requestSubscriptionKeys
+      description: |-
+        Requests the E2E encryption keys for the rooms the authenticated user is subscribed to. Other room members are notified to share their keys with the requesting user. This endpoint replaces the deprecated `e2e.requestSubscriptionKeys` DDP method. 
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ------------|
+        | 8.6.0   | Added       |
+      tags:
+        - E2E
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '401':
+          $ref: '#/components/responses/authorizationError'
   /api/v1/uploadImportFile:
     parameters: []
     post:

--- a/settings.yaml
+++ b/settings.yaml
@@ -266,6 +266,104 @@ paths:
           description: 'When set to true, it fetches both the current value and the default value (packageValue) of the settings'
         - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/count'
+    post:
+      summary: Update Settings in Bulk
+      operationId: post-api-v1-settings
+      description: |-
+        Update multiple private settings in a single request.This endpoint replaces the deprecated `saveSettings` DDP method.
+
+        Permission required: `Edit Privileged Setting` 
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.6.0            | Added       |
+      tags:
+        - Settings
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+        - $ref: '#/components/parameters/x-2fa-code'
+        - $ref: '#/components/parameters/X-2fa-method'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                settings:
+                  type: array
+                  description: The list of settings to update.
+                  minItems: 1
+                  items:
+                    type: object
+                    properties:
+                      _id:
+                        type: string
+                        description: The unique ID of the setting.
+                      value:
+                        description: The value to set for the setting. The accepted type depends on the setting.
+                    required:
+                      - _id
+                      - value
+              required:
+                - settings
+            examples:
+              Example:
+                value:
+                  settings:
+                    - _id: API_Allow_Infinite_Count
+                      value: false
+                    - _id: API_CORS_Origin
+                      value: 'https://example.com'
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid Params:
+                  value:
+                    success: false
+                    error: 'must have required property ''settings'' [invalid-params]'
+                    errorType: invalid-params
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Permission Error:
+                  value:
+                    success: false
+                    error: 'Editing settings is not allowed [error-action-not-allowed]'
+                    errorType: error-action-not-allowed
+                    details:
+                      method: saveSettings
+                      settingIds:
+                        - API_Allow_Infinite_Count
+                        - API_CORS_Origin
   /api/v1/settings.addCustomOAuth:
     parameters: []
     post:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -3517,7 +3517,7 @@ paths:
                   errorType:
                     type: string
               examples:
-                Example 1:
+                Invalid Parameter:
                   value:
                     success: false
                     error: 'must have required property ''data'' [invalid-params]'
@@ -3529,6 +3529,7 @@ paths:
         ### Changelog
         | Version      | Description |
         | ---------------- | ------------|
+        |8.6.0            | Added `utcOffset` property.       |
         |2.3.0            | Added `desktopNotificationRequireInteraction` property.       |
       parameters:
         - $ref: '#/components/parameters/UserId'
@@ -3733,8 +3734,12 @@ paths:
                     enableMobileRinging:
                       type: boolean
                       description: 'If you are using the Rocket.Chat Voice feature, you can set this parameter to true for mobile call notifications.'
+                    utcOffset:
+                      type: number
+                      description: The user's UTC offset in hours. Used to localize times such as notification schedules.
+                      example: -3
             examples:
-              Example 1:
+              Example:
                 value:
                   userId: rbAXPnMktTFbNpwtJ
                   data:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -5363,19 +5363,19 @@ paths:
                   errorType:
                     type: string
               examples:
-                Example 1:
+                Missing parameter:
                   value:
                     success: false
                     error: 'must have required property ''email'' [invalid-params]'
                     errorType: invalid-params
-        '401':
-          $ref: '#/components/responses/authorizationError'
       operationId: post-api-v1-users.sendConfirmationEmail
       description: |-
-       Send an email to verify a user's email address. The user receives the email and they must click the confirmation button to confirm their email address. Rate limit applies: One request can be sent every 60000ms.
-      parameters:
-        - $ref: '#/components/parameters/Auth-Token'
-        - $ref: '#/components/parameters/UserId'
+       Send an email to verify a user's email address. The user receives the email and they must click the confirmation button to confirm their email address. Rate limit applies: One request can be sent every 60000ms. This endpoint does not require authentication. An unverified user can call it from the login screen to resend their own verification email.
+       
+       ### Changelog
+        | Version    | Description                            |
+        | ---------- | -------------------------------------- |
+        | 8.6.0 | Authentication is no longer required.  |
       requestBody:
         content:
           application/json:
@@ -5389,7 +5389,7 @@ paths:
                   description: Enter the email address that needs to be verified.
                   example: example@example.com
             examples:
-              Example 1:
+              Example:
                 value:
                   email: example@example.com
   /api/v1/users.listByStatus:


### PR DESCRIPTION
Document REST API changes for the 8.6.0 release.

New endpoints:

- POST /api/v1/custom-sounds.delete (content-management.yaml)
- POST /api/v1/fingerprint — now documents the manage-cloud authorization requirement (miscellaneous.yaml)
- POST /api/v1/rooms.join (rooms.yaml)
- POST /api/v1/im.blockUser (messaging.yaml)
- POST /api/v1/e2e.requestSubscriptionKeys, POST /api/v1/settings (settings.yaml)

Updated endpoints:

- POST /api/v1/chat.delete — add fileId (messaging.yaml)
- GET /api/v1/spotlight — add usernames/type/rid + anonymous read (miscellaneous.yaml)
- POST /api/v1/users.setPreferences — add utcOffset (user-management.yaml)
- POST /api/v1/users.sendConfirmationEmail — authentication no longer required (user-management.yaml)
