### PR TITLE
Document 8.7 permission enforcement

### DIFF
--- a/rooms.yaml
+++ b/rooms.yaml
@@ -4526,7 +4526,14 @@ paths:
       summary: Convert Channel to Team
       description: |-
         Convert a channel to a team.
-        Permissions required: `create-team`, `edit-room`
+
+        Permissions required: `create-team`, `edit-room`. Both permissions are checked against the target channel, whether you identify it by `channelId` or `channelName`.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.7.0   | Enforced room permission checks regardless of whether the channel is identified by ID or name. |
+        | 3.13.0  | Added |
       operationId: post-api-v1-channels.convertToTeam
       parameters:
         - $ref: '#/components/parameters/Auth-Token'
@@ -4539,13 +4546,22 @@ paths:
               properties:
                 channelId:
                   type: string
-                  description: The channel's ID. Alternatively, enter the `channelName` parameter and provide the channel's name as the value.
-              required:
-                - channelId
+                  description: The channel's ID. Provide either `channelId` or `channelName`, but not both.
+                channelName:
+                  type: string
+                  description: The channel's name. Provide either `channelName` or `channelId`, but not both.
+              oneOf:
+                - required:
+                    - channelId
+                - required:
+                    - channelName
             examples:
-              Example:
+              Convert channel by ID:
                 value:
                   channelId: 6513afeda2f73c7460e18c86
+              Convert channel by name:
+                value:
+                  channelName: messages
       responses:
         '200':
           description: OK
@@ -4579,7 +4595,7 @@ paths:
                   success:
                     type: boolean
               examples:
-                Success:
+                Channel converted to team:
                   value:
                     team:
                       _id: 65149c7ea2f73c7460e18cab
@@ -4594,6 +4610,22 @@ paths:
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+              examples:
+                Missing channel permissions:
+                  value:
+                    success: false
+                    error: unauthorized
   /api/v1/rooms.saveNotification:
     post:
       tags:
@@ -7341,9 +7373,15 @@ paths:
         - Teams
       summary: Create a New Team
       description: |-
-        Create a new public or private team in the workspace. 
-        
-        Permission required: `create-team`
+        Create a new public or private team in the workspace.
+
+        Permission required: `create-team`. When you create a team from an existing room by passing `room.id`, you also need the `edit-room` permission for that room.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.7.0   | Enforced room permission checks when creating a team from an existing room. |
+        | 3.13.0  | Added |
       operationId: post-api-v1-teams.create
       parameters:
         - $ref: '#/components/parameters/Auth-Token'
@@ -7368,6 +7406,9 @@ paths:
                 room:
                   type: object
                   properties:
+                    id:
+                      type: string
+                      description: The ID of an existing room to use as the team's main room.
                     readOnly:
                       type: boolean
                 sidepanel:
@@ -7387,7 +7428,7 @@ paths:
                 - name
                 - type
             examples:
-              Example:
+              Create a public team:
                 value:
                   name: teamName
                   type: 0
@@ -7399,6 +7440,12 @@ paths:
                     items:
                       - discussions
                       - channels
+              Create a team from an existing room:
+                value:
+                  name: teamName
+                  type: 0
+                  room:
+                    id: 6513afeda2f73c7460e18c86
       responses:
         '200':
           description: |-
@@ -7435,7 +7482,7 @@ paths:
                   success:
                     type: boolean
               examples:
-                Success:
+                Team created:
                   value:
                     team:
                       _id: 651619e3a2f73c7460e18cc5
@@ -7450,6 +7497,22 @@ paths:
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+              examples:
+                Missing room permissions:
+                  value:
+                    success: false
+                    error: unauthorized
   /api/v1/teams.listAll:
     get:
       tags:

--- a/user-management.yaml
+++ b/user-management.yaml
@@ -3203,12 +3203,13 @@ paths:
         As a workspace admin, you can create temporary authentication tokens for users. This is the same type of session authentication token a user gets via <a href="https://developer.rocket.chat/apidocs/login-with-username-and-password" target="_blank">login</a> and expires the same way.
         * To use this endpoint, you must set a secret with the `CREATE_TOKENS_FOR_USERS_SECRET` <a href="https://docs.rocket.chat/docs/deployment-environment-variables" target="_blank">environment variable</a> in your deployment configuration. This secret will be used to authorize all requests made to this endpoint.
         * For SaaS workspaces, <a href="https://desk.rocket.chat/portal/en/signin" target="_blank">contact</a> support to set this variable.
-        * Permission required: `user-generate-access-token`
+        * Permission required: `user-generate-access-token`. This permission is required only when you generate a token for another user; it is not required when you generate a token for your own account.
         * The maximum number of login tokens per user is 50. See this <a href='https://github.com/RocketChat/Rocket.Chat/pull/32216' target='_blank'>GitHub PR</a> for details.
           
         ### Changelog
           | Version      | Description |
           | ---------------- | ------------|
+          |8.7.0             | Enforced the `user-generate-access-token` permission when generating a token for another user.|
           |8.0.0             | Added `CREATE_TOKENS_FOR_USERS_SECRET` <a href="https://docs.rocket.chat/docs/deployment-environment-variables" target="_blank">environment variable</a> to define a shared secret that will be used to authorize this endpoint.|
           |2.1.0            | Added ENV VAR to be able to use this endpoint (process.env.CREATE_TOKENS_FOR_USERS).       |
           |0.56.0            | Added       |
@@ -3236,7 +3237,7 @@ paths:
                 - userId
                 - secret
             examples:
-              Example:
+              Create token for a user:
                 value:
                   userId: BsNr28znDkG8aeo7W
                   secret: pass123
@@ -3258,7 +3259,7 @@ paths:
                   success:
                     type: boolean
               examples:
-                Success Example:
+                Token created:
                   value:
                     data:
                       userId: BsNr28znDkG8aeo7W
@@ -3286,6 +3287,11 @@ paths:
                       [error-user-param-not-provided]
                     errorType: error-user-param-not-provided
                 Invalid secret:
+                  value:
+                    success: false
+                    error: 'Not authorized [error-not-authorized]'
+                    errorType: error-not-authorized
+                Missing permission:
                   value:
                     success: false
                     error: 'Not authorized [error-not-authorized]'


### PR DESCRIPTION
### Summary
Documents REST API permission-enforcement hardening introduced in Rocket.Chat 8.7.0.

### Changes
 `user-management.yaml`
- Clarifies that `users.createToken` requires `user-generate-access-token` only when generating a token for another user.
- Documents the missing-permission `400` response.
- Adds descriptive request and response example names.
- Adds the `8.7.0` security-fix changelog entry.

`rooms.yaml`
- Documents consistent `create-team` and `edit-room` checks for `channels.convertToTeam`.
- Adds `channelName` to the request schema and requires either `channelId` or `channelName`.
- Documents the `403` permission response.
- Clarifies that `teams.create` also requires `edit-room` when using an existing room.
- Adds the missing `room.id` request field.
- Adds descriptive request and response examples.
- Adds the `3.13.0` introduction and `8.7.0` security-fix changelog entries for both endpoints.

### Related PRs
https://github.com/RocketChat/Rocket.Chat/pull/40768
https://github.com/RocketChat/Rocket.Chat/pull/41206