### PR TITLE
8.8 Document REST endpoint migrations

### DIFF
--- a/authentication.yaml
+++ b/authentication.yaml
@@ -1199,6 +1199,411 @@ paths:
                       method: password
                       codeGenerated: false
                       availableMethods: []
+  /api/v1/users.enableTotp:
+    post:
+      tags:
+        - Two-Factor Authentication
+      summary: Enable TOTP 2FA
+      description: |-
+        Starts the TOTP enrollment for your own account and returns the shared `secret` and the `url` to render as a QR code in an authenticator app. Call `users.validateTotp` with a code from the app to finish the enrollment.
+
+        This endpoint requires two-factor verification, so the account owner confirms their identity with an existing second factor before a new authenticator is registered. Requests are limited to five per minute.
+
+        This endpoint replaces the deprecated `2fa:enable` real-time method, which remains available until 9.0.0.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.8.0   | Added       |
+      operationId: post-api-v1-users.enableTotp
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+        - name: X-2fa-Code
+          in: header
+          description: 'The 2FA code. '
+          required: true
+          schema:
+            type: string
+        - schema:
+            type: string
+          in: header
+          name: X-2fa-method
+          description: 'The 2FA method. It can be `email`, `totp`, or `password`.'
+          required: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  secret:
+                    type: string
+                  url:
+                    type: string
+                  success:
+                    type: boolean
+                required:
+                  - secret
+                  - url
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    secret: KZ3EAT7RJVHUYQ2C
+                    url: 'otpauth://totp/Rocket.Chat:dana.reyes?secret=KZ3EAT7RJVHUYQ2C&issuer=Rocket.Chat'
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+                  details:
+                    type: object
+                    properties:
+                      method:
+                        type: string
+                      codeGenerated:
+                        type: boolean
+                      availableMethods:
+                        type: array
+                        items:
+                          type: object
+              examples:
+                TOTP Required:
+                  value:
+                    success: false
+                    error: 'TOTP Required [totp-required]'
+                    errorType: totp-required
+                    details:
+                      method: password
+                      codeGenerated: false
+                      availableMethods: []
+        '401':
+          $ref: '#/components/responses/authorizationError'
+  /api/v1/users.validateTotp:
+    post:
+      tags:
+        - Two-Factor Authentication
+      summary: Validate TOTP Code
+      description: |-
+        Finishes the TOTP enrollment started with `users.enableTotp` by validating a code from the authenticator app, and returns the backup `codes` for the account. The other login tokens of the account are rotated, except personal access tokens.
+
+        This endpoint requires two-factor verification. Requests are limited to five per minute.
+
+        This endpoint replaces the deprecated `2fa:validateTempToken` real-time method, which remains available until 9.0.0.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.8.0   | Added       |
+      operationId: post-api-v1-users.validateTotp
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+        - name: X-2fa-Code
+          in: header
+          description: 'The 2FA code. '
+          required: true
+          schema:
+            type: string
+        - schema:
+            type: string
+          in: header
+          name: X-2fa-method
+          description: 'The 2FA method. It can be `email`, `totp`, or `password`.'
+          required: true
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  description: The code shown by the authenticator app for the account.
+                  example: '482913'
+              required:
+                - code
+              additionalProperties: false
+            examples:
+              Example 1:
+                value:
+                  code: '482913'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  codes:
+                    type: array
+                    description: The backup codes of the account.
+                    items:
+                      type: string
+                  success:
+                    type: boolean
+                required:
+                  - codes
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    codes:
+                      - 3f7a1c9d
+                      - 90b2e4a6
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid code:
+                  value:
+                    success: false
+                    error: '[invalid-totp]'
+                    errorType: invalid-totp
+        '401':
+          $ref: '#/components/responses/authorizationError'
+  /api/v1/users.disableTotp:
+    post:
+      tags:
+        - Two-Factor Authentication
+      summary: Disable TOTP 2FA
+      description: |-
+        Disables the authenticator app (TOTP) two-factor authentication of your own account. The code from the authenticator app is required in the body. Requests are limited to five per minute.
+
+        This endpoint replaces the deprecated `2fa:disable` real-time method, which remains available until 9.0.0.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.8.0   | Added       |
+      operationId: post-api-v1-users.disableTotp
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  description: The code shown by the authenticator app for the account.
+                  example: '482913'
+              required:
+                - code
+              additionalProperties: false
+            examples:
+              Example 1:
+                value:
+                  code: '482913'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  disabled:
+                    type: boolean
+                  success:
+                    type: boolean
+                required:
+                  - disabled
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    disabled: true
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+        '401':
+          $ref: '#/components/responses/authorizationError'
+  /api/v1/users.regenerateTotpCodes:
+    post:
+      tags:
+        - Two-Factor Authentication
+      summary: Regenerate TOTP Backup Codes
+      description: |-
+        Generates a new set of backup codes for the authenticator app (TOTP) two-factor authentication of your own account and returns them. The previous backup codes stop working. The code from the authenticator app is required in the body. Requests are limited to five per minute.
+
+        This endpoint replaces the deprecated `2fa:regenerateCodes` real-time method, which remains available until 9.0.0.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.8.0   | Added       |
+      operationId: post-api-v1-users.regenerateTotpCodes
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  description: The code shown by the authenticator app for the account.
+                  example: '482913'
+              required:
+                - code
+              additionalProperties: false
+            examples:
+              Example 1:
+                value:
+                  code: '482913'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  codes:
+                    type: array
+                    description: The new backup codes of the account.
+                    items:
+                      type: string
+                  success:
+                    type: boolean
+                required:
+                  - codes
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    codes:
+                      - 5c1d8b02
+                      - e74a2f61
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Invalid code:
+                  value:
+                    success: false
+                    error: '[invalid-totp]'
+                    errorType: invalid-totp
+        '401':
+          $ref: '#/components/responses/authorizationError'
+  /api/v1/users.totpCodesRemaining:
+    get:
+      tags:
+        - Two-Factor Authentication
+      summary: Get Remaining TOTP Codes
+      description: |-
+        Returns how many backup codes are left for the authenticator app (TOTP) two-factor authentication of your own account. Requests are limited to five per minute.
+
+        This endpoint replaces the deprecated `2fa:checkCodesRemaining` real-time method, which remains available until 9.0.0.
+
+        ### Changelog
+        | Version | Description |
+        | ------- | ----------- |
+        | 8.8.0   | Added       |
+      operationId: get-api-v1-users.totpCodesRemaining
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  remaining:
+                    type: number
+                  success:
+                    type: boolean
+                required:
+                  - remaining
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    remaining: 8
+                    success: true
+        '400':
+          description: TOTP two-factor authentication is not enabled for the user.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                TOTP not enabled:
+                  value:
+                    success: false
+                    error: '[invalid-totp]'
+                    errorType: invalid-totp
+        '401':
+          $ref: '#/components/responses/authorizationError'
   /api/v1/twoFactorChallenges.sendEmailCode:
     post:
       tags:

--- a/messaging.yaml
+++ b/messaging.yaml
@@ -1933,6 +1933,83 @@ paths:
                     success: false
                     error: 'The provided "aroundId" does not belong to the thread [error-invalid-message]'
                     errorType: error-invalid-message
+  /api/v1/chat.readThread:
+    post:
+      tags:
+        - Chat
+      summary: Mark Thread as Read
+      description: |-
+        Marks a single thread as read for the authenticated user and removes it from the unread thread list in the user's subscription.
+
+        Use this endpoint when you need to mark one thread as read. The `subscriptions.read` endpoint operates on an entire room and cannot identify a single thread.
+
+        This endpoint replaces the deprecated `readThreads` realtime method, which remains available until Rocket.Chat 9.0.0.
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added       |
+      operationId: post-api-v1-chat.readThread
+      parameters:
+        - $ref: '#/components/parameters/Auth-Token'
+        - $ref: '#/components/parameters/UserId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tmid:
+                  type: string
+                  minLength: 1
+                  description: The ID of the thread's main message.
+              required:
+                - tmid
+              additionalProperties: false
+            examples:
+              Example:
+                value:
+                  tmid: 7aDSXtjMA3KPLxLjt
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: The request is invalid, threads are disabled, the message or room does not exist, or the user cannot access the room.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Threads disabled:
+                  value:
+                    success: false
+                    error: Threads Disabled [error-not-allowed]
+                    errorType: error-not-allowed
+                Invalid message:
+                  value:
+                    success: false
+                    error: Invalid Message [error-invalid-message]
+                    errorType: error-invalid-message
+                Room not found:
+                  value:
+                    success: false
+                    error: This room does not exist [error-room-does-not-exist]
+                    errorType: error-room-does-not-exist
+                Room access denied:
+                  value:
+                    success: false
+                    error: Not Allowed [error-not-allowed]
+                    errorType: error-not-allowed
+        '401':
+          $ref: '#/components/responses/authorizationError'
   /api/v1/chat.ignoreUser:
     get:
       tags:

--- a/notifications.yaml
+++ b/notifications.yaml
@@ -598,17 +598,45 @@ paths:
                 properties:
                   tokensCount:
                     type: integer
+                    description: The number of devices to which the test notification was sent.
+                  message:
+                    type: string
+                    description: The translation key for the test result message.
+                  params:
+                    type: array
+                    description: Values used to format the translated result message.
+                    items:
+                      type: integer
                   success:
                     type: boolean
+                required:
+                  - tokensCount
+                  - message
+                  - params
+                  - success
               examples:
                 Example 1:
                   value:
                     tokensCount: 1
+                    message: Your_push_was_sent_to_s_devices
+                    params:
+                      - 1
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
       operationId: post-api-v1-push.test
-      description: "Use this endpoint to test the push notifications configuration. Permission required: `test-push-notifications`.\r\nBy default, one request is allowed every 1000 milliseconds. To test successfully, make sure that you have logged into the workspace on the Rocket.Chat mobile app."
+      description: |-
+        Use this endpoint to test the push notifications configuration. The response indicates how many registered devices received the test notification.
+
+        To test successfully, make sure that you have logged into the workspace on the Rocket.Chat mobile app. By default, one request is allowed every 1000 milliseconds.
+
+        **Permission required**:
+        - `test-push-notifications`
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added the `message` and `params` response fields. |
       parameters:
         - $ref: '#/components/parameters/X-Auth-Token'
         - $ref: '#/components/parameters/X-User-Id'

--- a/settings.yaml
+++ b/settings.yaml
@@ -253,6 +253,8 @@ paths:
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
       tags:
         - Settings
       description: 'List all private settings. Learn how this can be used in configuring your server in this <a href="https://docs.rocket.chat/docs/deployment-environment-variables" target="_blank">guide</a>.'
@@ -376,7 +378,11 @@ paths:
   /api/v1/settings.addCustomOAuth:
     parameters: []
     post:
-      description: Add a <a href=" https://docs.rocket.chat/docs/oauth#add-custom-oauth" target="_blank">custom OAuth integration</a> to your workspace.
+      description: |-
+        Add a <a href="https://docs.rocket.chat/docs/oauth#add-custom-oauth" target="_blank">custom OAuth integration</a> to your workspace. Two-factor authentication is required.
+
+        **Permission required**:
+        - `add-oauth-service`
       summary: Add Custom OAuth
       operationId: post-api-v1-settings.addCustomOAuth
       responses:
@@ -403,6 +409,8 @@ paths:
                     errorType: error-name-param-not-provided
         '401':
           $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
       tags:
         - Settings
       parameters:
@@ -421,6 +429,105 @@ paths:
                   description: The name of the custom OAuth method that you want to add.
               required:
                 - name
+  /api/v1/settings.removeCustomOAuth:
+    parameters: []
+    post:
+      description: |-
+        Remove a <a href=" https://docs.rocket.chat/docs/oauth#add-custom-oauth" target="_blank">custom OAuth integration</a> from your workspace. All the `Accounts_OAuth_Custom-<Name>-*` settings of the named service are deleted. This endpoint requires 2FA.
+
+        It replaces the deprecated `removeOAuthService` real-time method, which remains available until 9.0.0.
+
+        **Permission required**:
+        - `add-oauth-service`
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added       |
+      summary: Remove Custom OAuth
+      operationId: post-api-v1-settings.removeCustomOAuth
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+              examples:
+                Missing name param:
+                  value:
+                    success: false
+                    error: 'The parameter "name" is required [error-name-param-not-provided]'
+                    errorType: error-name-param-not-provided
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
+      tags:
+        - Settings
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+        - $ref: '#/components/parameters/x-2fa-code'
+        - $ref: '#/components/parameters/X-2fa-method'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The name of the custom OAuth service that you want to remove.
+                  example: myProvider
+              required:
+                - name
+              additionalProperties: false
+            examples:
+              Example:
+                value:
+                  name: myProvider
+  /api/v1/settings.refreshOAuthServices:
+    parameters: []
+    post:
+      description: |-
+        Reload the workspace <a href=" https://docs.rocket.chat/docs/oauth" target="_blank">OAuth service</a> configurations from the current settings. Use it after adding or removing a custom OAuth service so that the login services are rebuilt. This endpoint takes no body and requires 2FA.
+
+        It replaces the deprecated `refreshOAuthService` real-time method, which remains available until 9.0.0.
+
+        **Permission required**:
+        - `add-oauth-service`
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added       |
+      summary: Refresh OAuth Services
+      operationId: post-api-v1-settings.refreshOAuthServices
+      responses:
+        '200':
+          $ref: '#/components/responses/trueSuccess'
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
+      tags:
+        - Settings
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+        - $ref: '#/components/parameters/x-2fa-code'
+        - $ref: '#/components/parameters/X-2fa-method'
   '/api/v1/settings/{_id}':
     parameters:
       - schema:
@@ -4999,8 +5106,456 @@ paths:
                     success: true
         '401':
           $ref: '#/components/responses/authorizationError'
+  /api/v1/audit.auditions:
+    parameters: []
+    get:
+      tags:
+        - Audit
+      summary: List Auditions
+      description: |-
+        <div style="text-align: center; margin: 1rem 0 1rem 0;"><img src="https://raw.githubusercontent.com/RocketChat/Rocket.Chat-Open-API/main/images/premium.svg" alt="Premium tag" style="display: block; margin: auto;"></div>
+
+        Lists the audit searches performed during a specified period. This endpoint requires a license that includes the `auditing` module. Dates use ISO 8601 format. Requests are limited to ten per minute.
+
+        This endpoint replaces the deprecated `auditGetAuditions` real-time method, which remains available until 9.0.0.
+
+        **Permission required**:
+        - `can-audit-log`
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added       |
+      operationId: get-api-v1-audit.auditions
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+        - name: startDate
+          in: query
+          required: true
+          description: The beginning of the period to list, as an ISO date string.
+          schema:
+            type: string
+            format: date-time
+          example: '2026-08-01T00:00:00.000Z'
+        - name: endDate
+          in: query
+          required: true
+          description: The end of the period to list, as an ISO date string.
+          schema:
+            type: string
+            format: date-time
+          example: '2026-08-20T23:59:59.999Z'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  auditions:
+                    type: array
+                    description: The audit log entries recorded in the requested period.
+                    items:
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                        _updatedAt:
+                          type: string
+                          format: date-time
+                        ts:
+                          type: string
+                          format: date-time
+                        results:
+                          type: number
+                        u:
+                          type: object
+                          properties:
+                            _id:
+                              type: string
+                            username:
+                              type: string
+                            name:
+                              type: string
+                            avatarETag:
+                              type: string
+                          required:
+                            - _id
+                          additionalProperties: false
+                        fields:
+                          type: object
+                          properties:
+                            type:
+                              type: string
+                            msg:
+                              type: string
+                              nullable: true
+                            startDate:
+                              type: string
+                              format: date-time
+                              nullable: true
+                            endDate:
+                              type: string
+                              format: date-time
+                              nullable: true
+                            rids:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                            room:
+                              type: string
+                              nullable: true
+                            users:
+                              type: array
+                              nullable: true
+                              items:
+                                type: string
+                            visitor:
+                              type: string
+                              nullable: true
+                            agent:
+                              type: string
+                              nullable: true
+                            filters:
+                              type: string
+                              nullable: true
+                          required:
+                            - type
+                          additionalProperties: false
+                      required:
+                        - _id
+                        - ts
+                        - results
+                        - u
+                        - fields
+                      additionalProperties: false
+                  success:
+                    type: boolean
+                required:
+                  - auditions
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    auditions: []
+                    success: true
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
+  /api/v1/audit.messages:
+    parameters: []
+    post:
+      tags:
+        - Audit
+      summary: Audit Messages
+      description: |-
+        <div style="text-align: center; margin: 1rem 0 1rem 0;"><img src="https://raw.githubusercontent.com/RocketChat/Rocket.Chat-Open-API/main/images/premium.svg" alt="Premium tag" style="display: block; margin: auto;"></div>
+
+        Searches messages for an audit and records the search in the audit log. This endpoint requires a license that includes the `auditing` module. Dates use ISO 8601 format. Requests are limited to ten per minute.
+
+        This endpoint replaces the deprecated `auditGetMessages` real-time method, which remains available until 9.0.0.
+
+        **Permission required**:
+        - `can-audit`
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added       |
+      operationId: post-api-v1-audit.messages
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rid:
+                  type: string
+                  description: The ID of the room to search in. Optional.
+                  example: GENERAL
+                startDate:
+                  type: string
+                  format: date-time
+                  description: The beginning of the period to search, as an ISO date string.
+                  example: '2026-08-01T00:00:00.000Z'
+                endDate:
+                  type: string
+                  format: date-time
+                  description: The end of the period to search, as an ISO date string.
+                  example: '2026-08-20T23:59:59.999Z'
+                users:
+                  type: array
+                  description: The usernames whose messages are audited.
+                  items:
+                    type: string
+                  example:
+                    - dana.reyes
+                msg:
+                  type: string
+                  nullable: true
+                  description: The text to search for in the messages.
+                  example: incident report
+                type:
+                  type: string
+                  description: The audit target. Use `u` for users, `d` for a direct message, or `l` for Omnichannel rooms. When `rid` is provided, the room ID determines the target.
+                  example: u
+                visitor:
+                  type: string
+                  nullable: true
+                  description: The ID of the Omnichannel visitor to audit.
+                  example: 8f4c2d1e9a7b6c5d3e2f1a0b
+                agent:
+                  type: string
+                  nullable: true
+                  description: The ID of the Omnichannel agent to audit.
+                  example: rbAXPnMktTFbNpwtJ
+              required:
+                - startDate
+                - endDate
+                - users
+                - msg
+                - type
+              additionalProperties: false
+            examples:
+              Example:
+                value:
+                  rid: GENERAL
+                  startDate: '2026-08-01T00:00:00.000Z'
+                  endDate: '2026-08-20T23:59:59.999Z'
+                  users:
+                    - dana.reyes
+                  msg: incident report
+                  type: u
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    description: The messages matching the audit search.
+                    items:
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                        rid:
+                          type: string
+                        msg:
+                          type: string
+                        ts:
+                          type: string
+                        u:
+                          type: object
+                          properties:
+                            _id:
+                              type: string
+                            username:
+                              type: string
+                            name:
+                              type: string
+                  success:
+                    type: boolean
+                required:
+                  - messages
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    messages:
+                      - _id: 7aDSXtjMA3KPLxLjt
+                        rid: GENERAL
+                        msg: Please share the incident report
+                        ts: '2026-08-12T09:14:03.412Z'
+                        u:
+                          _id: rbAXPnMktTFbNpwtJ
+                          username: dana.reyes
+                          name: Dana Reyes
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
+  /api/v1/audit.omnichannelMessages:
+    parameters: []
+    post:
+      tags:
+        - Audit
+      summary: Audit Omnichannel Messages
+      description: |-
+        <div style="text-align: center; margin: 1rem 0 1rem 0;"><img src="https://raw.githubusercontent.com/RocketChat/Rocket.Chat-Open-API/main/images/premium.svg" alt="Premium tag" style="display: block; margin: auto;"></div>
+
+        Searches <a href="https://docs.rocket.chat/docs/omnichannel" target="_blank">Omnichannel</a> messages for an audit and records the search in the audit log. This endpoint requires a license that includes the `auditing` module. Dates use ISO 8601 format. Requests are limited to ten per minute.
+
+        This endpoint replaces the deprecated `auditGetOmnichannelMessages` real-time method, which remains available until 9.0.0.
+
+        **Permission required**:
+        - `can-audit`
+
+        ### Changelog
+        | Version      | Description |
+        | ---------------- | ------------|
+        |8.8.0            | Added       |
+      operationId: post-api-v1-audit.omnichannelMessages
+      parameters:
+        - $ref: '#/components/parameters/X-User-Id'
+        - $ref: '#/components/parameters/X-Auth-Token'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                startDate:
+                  type: string
+                  format: date-time
+                  description: The beginning of the period to search, as an ISO date string.
+                  example: '2026-08-01T00:00:00.000Z'
+                endDate:
+                  type: string
+                  format: date-time
+                  description: The end of the period to search, as an ISO date string.
+                  example: '2026-08-20T23:59:59.999Z'
+                users:
+                  type: array
+                  description: The usernames associated with the audit search.
+                  items:
+                    type: string
+                  example:
+                    - dana.reyes
+                msg:
+                  type: string
+                  nullable: true
+                  description: The text to search for in the messages.
+                  example: refund
+                type:
+                  type: string
+                  description: The audit type recorded in the audit log.
+                  example: u
+                visitor:
+                  type: string
+                  nullable: true
+                  description: The ID of the Omnichannel visitor to audit.
+                  example: 8f4c2d1e9a7b6c5d3e2f1a0b
+                agent:
+                  type: string
+                  nullable: true
+                  description: The ID of the Omnichannel agent to audit.
+                  example: rbAXPnMktTFbNpwtJ
+              required:
+                - startDate
+                - endDate
+                - users
+                - msg
+                - type
+              additionalProperties: false
+            examples:
+              Example:
+                value:
+                  startDate: '2026-08-01T00:00:00.000Z'
+                  endDate: '2026-08-20T23:59:59.999Z'
+                  users:
+                    - dana.reyes
+                  msg: refund
+                  type: u
+                  visitor: 8f4c2d1e9a7b6c5d3e2f1a0b
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  messages:
+                    type: array
+                    description: The Omnichannel messages matching the audit search.
+                    items:
+                      type: object
+                      properties:
+                        _id:
+                          type: string
+                        rid:
+                          type: string
+                        msg:
+                          type: string
+                        ts:
+                          type: string
+                        u:
+                          type: object
+                          properties:
+                            _id:
+                              type: string
+                            username:
+                              type: string
+                            name:
+                              type: string
+                  success:
+                    type: boolean
+                required:
+                  - messages
+                  - success
+                additionalProperties: false
+              examples:
+                Success Example:
+                  value:
+                    messages:
+                      - _id: 5RQ4SBL3NuZKsqxaF
+                        rid: pMtJcZDsvKLnGKQ2C
+                        msg: I would like to request a refund
+                        ts: '2026-08-14T16:02:51.006Z'
+                        u:
+                          _id: 8f4c2d1e9a7b6c5d3e2f1a0b
+                          username: guest-482
+                          name: Alex Doe
+                    success: true
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  error:
+                    type: string
+                  errorType:
+                    type: string
+        '401':
+          $ref: '#/components/responses/authorizationError'
+        '403':
+          $ref: '#/components/responses/forbiddenError'
 tags:
   - name: Settings
+  - name: Audit
   - name: Cloud
   - name: DNS
   - name: E2E


### PR DESCRIPTION
## Summary

Documents the REST endpoints used to replace deprecated realtime DDP methods in Rocket.Chat 8.8.0.

- Added five TOTP two-factor authentication endpoints.
- Added two custom OAuth administration endpoints.
- Added three message auditing endpoints.
- Added the endpoint for marking an individual thread as read.
- Updated the push test response with the new `message` and `params` fields.
- Updated the existing custom OAuth endpoint with its permission and two-factor authentication requirements.
- Documented request fields, responses, errors, permissions, rate limits, and examples.