### PR TITLE
8.8 document bounded message sync

### DIFF
--- a/messaging.yaml
+++ b/messaging.yaml
@@ -3527,45 +3527,52 @@ paths:
         - Chat
       summary: Sync Messages
       description: |-
-        List the messages in a room along with any data updates from a specified date.
+        List updated and deleted messages in a room. Use `lastUpdate` to retrieve changes made after a specific date. To limit the results to messages originally sent at or after a specific date, use `fromTs` together with `lastUpdate`.
+
+        You can also paginate updated or deleted messages with the `next`, `previous`, and `type` parameters. This endpoint replaces the deprecated `loadMissedMessages` method, which is scheduled for removal in Rocket.Chat 9.0.0.
         ### Changelog
         | Version      | Description | 
         | ------------ | ------------|
+        | 8.8.0        | Added the `fromTs` parameter. |
         | 1.0.0        | Added       |
       operationId: get-api-v1-chat.syncMessages
       parameters:
         - $ref: '#/components/parameters/Auth-Token'
         - $ref: '#/components/parameters/UserId'
         - $ref: '#/components/parameters/RoomId'
-        - $ref: '#/components/parameters/offset'
         - $ref: '#/components/parameters/count'
-        - $ref: '#/components/parameters/sort'
         - name: lastUpdate
           in: query
-          description: 'The date as an ISO string. You cannot use this parameter if you are using the `next` or `previous` parameter.'
-          
+          description: The date and time after which message updates and deletions should be returned.
           schema:
             type: string
+            format: date-time
           example: 2019-04-16T18:30:46.669Z
-        - schema:
-            type: number
-            example: 14182940000
+        - name: fromTs
           in: query
-          name: next
-          description: 'This indicates whether the query should retrieve items from a **later** point in time. The value must be the number of milliseconds, as it follows [Date getTime()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime). Note that you can use either `next` or `previous` at the same time.'
-        - schema:
-            type: number
-            example: 14182940000
-          in: query
-          name: previous
-          description: 'This indicates whether the query should retrieve items from an **earlier** point in time. The value must be the number of milliseconds, as it follows [Date getTime()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime).'
-        - schema:
+          description: The inclusive date and time boundary for the original message timestamp. Only messages originally sent at or after this date are considered. You must use this parameter together with `lastUpdate`.
+          schema:
             type: string
+            format: date-time
+          example: 2019-04-01T00:00:00.000Z
+        - name: next
           in: query
-          name: type
-          description: 'You must specify whether you want to retrieve `DELETED` (for deleted messages) or `UPDATED` (for updated messages, which is the default use case). This parameter is **required** if you are using the `next` or `previous` parameter.'
-            
-            # > **NOTE:** `offset`, `sort`, and `count` are optional parameters. By default, the endpoint returns 20 items if you don't specify a value for `count`. According to the remaining query parameters you use, this endpoint returns the messages in two ways: * With the `lastUpdate` parameter: If you use the `lastUpdate` parameter, the endpoint returns the messages updated since the specified date. * With the cursor based pagination: For this approach, you must enter either the `next` or the `previous` parameter, and `type` is a mandatory field. In this case, the `lastUpdate` parameter cannot be used.
+          description: The cursor returned in `result.cursor.next` to retrieve the next page. Use either `next` or `previous`.
+          schema:
+            type: string
+        - name: previous
+          in: query
+          description: The cursor returned in `result.cursor.previous` to retrieve the previous page. Use either `next` or `previous`.
+          schema:
+            type: string
+        - name: type
+          in: query
+          description: The message change type to retrieve when using cursor pagination. This parameter is required with `next` or `previous`.
+          schema:
+            type: string
+            enum:
+              - UPDATED
+              - DELETED
       responses:
         '200':
           description: OK
@@ -3643,6 +3650,24 @@ paths:
                         type: array
                         items:
                           type: object
+                          required:
+                            - _id
+                            - _deletedAt
+                          properties:
+                            _id:
+                              type: string
+                            _deletedAt:
+                              type: string
+                              format: date-time
+                      cursor:
+                        type: object
+                        properties:
+                          next:
+                            type: string
+                            nullable: true
+                          previous:
+                            type: string
+                            nullable: true
                   success:
                     type: boolean
               examples:
@@ -3708,18 +3733,23 @@ paths:
                 Example 1:
                   value:
                     success: false
-                    error: 'The required "roomId" query param is missing. [error-roomId-param-not-provided]'
-                    errorType: error-roomId-param-not-provided
+                    error: 'The required "roomId" query param is missing [error-param-required]'
+                    errorType: error-param-required
                 Example 2:
                   value:
                     success: false
-                    error: 'The required "lastUpdate" query param is missing. [error-lastUpdate-param-not-provided]'
-                    errorType: error-lastUpdate-param-not-provided
+                    error: 'The "type" or "lastUpdate" parameters must be provided [error-param-required]'
+                    errorType: error-param-required
                 Example 3:
                   value:
                     success: false
-                    error: 'The "lastUpdate" query parameter must be a valid date. [error-roomId-param-invalid]'
-                    errorType: error-roomId-param-invalid
+                    error: 'The "lastUpdate" query parameter must be a valid date [error-lastUpdate-param-invalid]'
+                    errorType: error-lastUpdate-param-invalid
+                Example 4:
+                  value:
+                    success: false
+                    error: 'The "fromTs" parameter can only be used together with "lastUpdate" [error-fromTs-requires-lastUpdate]'
+                    errorType: error-fromTs-requires-lastUpdate
   /api/v1/chat.getURLPreview:
     get:
       summary: Get URL Preview


### PR DESCRIPTION
## Summary

Updated the documentation for `GET /api/v1/chat.syncMessages`.

- Added the new 8.8.0 `fromTs` parameter.
- Explained how `fromTs` works with `lastUpdate`.
- Corrected the documented pagination parameters and types.
- Documented the cursor and deleted-message response fields.
- Corrected the 400 error examples.
- Noted that this endpoint replaces the deprecated `loadMissedMessages` method.